### PR TITLE
Remove listing tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Get all git commits and tags
         run: git fetch --prune --unshallow --tags
 
-      - name: List git tags
-        run: git tag
-
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x


### PR DESCRIPTION
This was added when trying to determine why the `main` branch canary release wasn't working. The tag was associated to the merge commit which is ignored when reading the git logs back into `dripip`. The merge rules were updated and the this config is no longer needed to debug but will be useful to merge to validate that it now works after manually tagging a commit since it was trying to re-release `next.1`.