### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "version": "0.0.0-dripip",
+  "bugs": {
+    "url": "https://github.com/skovy/css-codemod/issues"
+  },
   "license": "MIT",
   "name": "css-codemod",
   "author": "Spencer Miskoviak",


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.